### PR TITLE
feat: add enableConfirmationText option to show an input field for user to enter confirmation text

### DIFF
--- a/apps/web/app/components/types.tsx
+++ b/apps/web/app/components/types.tsx
@@ -202,6 +202,33 @@ console.log(result ? 'Confirmed' : 'Canceled')`,
     }
   },
   {
+    name: 'Text Confirmation',
+    snippet: `await confirm({
+  title: 'Confirm Deletion',
+  description: 'This action is irreversible. Please type "delete" to confirm.',
+  enableConfirmationText: 'delete',
+  enableConfirmationTextPlaceholder:
+    'Type "delete" to enable the confirm button',
+  confirmText: 'Delete Permanently',
+  confirmButton: {
+    className: 'bg-red-500 hover:bg-red-600 text-white'
+  }
+})`,
+    action: (confirm: (options: ConfirmOptions) => Promise<boolean>) => {
+      confirm({
+        title: 'Confirm Deletion',
+        description: 'This action is irreversible. Please type "delete" to confirm.',
+        enableConfirmationText: 'delete',
+        enableConfirmationTextPlaceholder:
+          'Type "delete" to enable the confirm button',
+        confirmText: 'Delete Permanently',
+        confirmButton: {
+          className: 'bg-red-500 hover:bg-red-600 text-white'
+        }
+      })
+    }
+  },
+  {
     name: 'Custom Actions',
     snippet: `await confirm({
   title: 'Custom Actions',

--- a/packages/confirm-dialog/src/components/ui/input.tsx
+++ b/packages/confirm-dialog/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/packages/confirm-dialog/src/confirm-dialog.tsx
+++ b/packages/confirm-dialog/src/confirm-dialog.tsx
@@ -19,6 +19,7 @@ import {
   AlertDialogPortal,
   AlertDialogTitle
 } from '@/components/ui/alert-dialog'
+import { Input } from '@/components/ui/input'
 
 export interface ConfirmOptions {
   title?: React.ReactNode
@@ -26,6 +27,8 @@ export interface ConfirmOptions {
   confirmText?: string
   cancelText?: string
   icon?: React.ReactNode
+  enableConfirmationText?: string
+  enableConfirmationTextPlaceholder?: string
   customActions?: (
     onConfirm: () => void,
     onCancel: () => void
@@ -69,15 +72,18 @@ const ConfirmDialogContent: React.FC<{
   onConfirm: () => void
   onCancel: () => void
 }> = memo(({ config, onConfirm, onCancel }) => {
+  const [confirmText, setConfirmText] = useState('')
   const {
     title,
     description,
     cancelButton,
     confirmButton,
-    confirmText,
+    confirmText: confirmButtonText,
     cancelText,
     icon,
     customActions,
+    enableConfirmationText,
+    enableConfirmationTextPlaceholder,
     alertDialogOverlay,
     alertDialogContent,
     alertDialogHeader,
@@ -85,6 +91,8 @@ const ConfirmDialogContent: React.FC<{
     alertDialogDescription,
     alertDialogFooter
   } = config
+
+  const isConfirmDisabled = enableConfirmationText ? confirmText !== enableConfirmationText : false
 
   return (
     <AlertDialogPortal>
@@ -102,6 +110,19 @@ const ConfirmDialogContent: React.FC<{
               {description}
             </AlertDialogDescription>
           )}
+          {enableConfirmationText && (
+            <Input
+              value={confirmText}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setConfirmText(e.target.value)
+              }}
+              placeholder={
+                enableConfirmationTextPlaceholder ||
+                `To continue type: "${enableConfirmationText}"`
+              }
+              className="mt-4"
+            />
+          )}
         </AlertDialogHeader>
         <AlertDialogFooter {...alertDialogFooter}>
           {customActions ? (
@@ -113,8 +134,12 @@ const ConfirmDialogContent: React.FC<{
                   {cancelText}
                 </AlertDialogCancel>
               )}
-              <AlertDialogAction onClick={onConfirm} {...confirmButton}>
-                {confirmText}
+              <AlertDialogAction 
+                onClick={onConfirm} 
+                {...confirmButton}
+                disabled={isConfirmDisabled}
+              >
+                {confirmButtonText}
               </AlertDialogAction>
             </>
           )}


### PR DESCRIPTION
<img width="715" alt="Screenshot 2024-10-31 at 02 32 56" src="https://github.com/user-attachments/assets/b1e424c8-8792-4b5c-8ee6-494d3d23b834">
<img width="544" alt="Screenshot 2024-10-31 at 02 28 27" src="https://github.com/user-attachments/assets/e6260cc6-e529-46cc-9d12-df548cf1693a">
