### PR TITLE
added margin to the buttons inside when in mobile

### DIFF
--- a/packages/confirm-dialog/src/components/ui/button.tsx
+++ b/packages/confirm-dialog/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center  justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
@@ -20,8 +20,8 @@ const buttonVariants = cva(
         link: 'text-primary underline-offset-4 hover:underline'
       },
       size: {
-        default: 'h-9 px-4 py-2',
-        sm: 'h-8 rounded-md px-3 text-xs',
+        default: 'h-9 px-4 py-2 mb-2',
+        sm: 'h-8 rounded-md  px-3 text-xs',
         lg: 'h-10 rounded-md px-8',
         icon: 'h-9 w-9'
       }


### PR DESCRIPTION
Fixed mobile UI issues with pop-up buttons

This PR addresses UI rendering problems with pop-up buttons on mobile devices. The buttons weren't displaying properly on smaller screens, causing usability issues for mobile users

Changes include:
- Adjusted button positioning for proper display on mobile viewports


Tested on multiple mobile screen sizes to verify fix.